### PR TITLE
Update GitHub Actions workflows and dependencies

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deny major updates
-        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' }}
+        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' && steps.dependabot-metadata.outputs.package-ecosystem != 'github-actions' }}
         run: |
           gh pr review "$PR_URL" --request-changes -b "🚫 Denied: This PR includes a **major update**, which is not allowed."
           gh pr close "$PR_URL"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.0.0
 
       - name: Approve and auto-merge minor and patch updates
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # Check out the repository so the action can read the manifest files.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
 
@@ -47,7 +47,7 @@ jobs:
       # retry-on-snapshot-warnings retries if GitHub's dependency graph hasn't
       # indexed the commit yet, ensuring a complete scan before passing.
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.9.0
         with:
           comment-summary-in-pr: always
           fail-on-severity: low


### PR DESCRIPTION
Update the workflows to use the latest versions of `fetch-metadata`, `checkout`, and `dependency-review-action`. Restrict major update denials to non-GitHub Actions packages in the automerge workflow.