### PR TITLE
Refactor dependency review workflow settings

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,24 +3,20 @@
 name: "Dependency review"
 
 # Run on every pull request targeting main.
-# Scans dependency manifest changes (node/package.json, golang/go.mod, etc.)
-# against GitHub's advisory database for known CVEs.
+# Scans dependency manifest changes against GitHub's advisory database for known CVEs.
 # When set as a required status check, this blocks automerge (and manual merges)
 # if a vulnerable dependency is introduced -- even via Dependabot patch/minor PRs.
+# Note: no paths filter -- the action exits cleanly when no manifests changed,
+# which keeps the required status check satisfied for all PRs.
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "node/package.json"
-      - "node/package-lock.json"
-      - "golang/go.mod"
-      - "golang/go.sum"
 
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
 permissions:
   contents: read
   # Required for comment-summary-in-pr to post results as a PR comment.
@@ -34,7 +30,7 @@ env:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       # Check out the repository so the action can read the manifest files.
       - name: Checkout repository


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for dependency review to simplify its configuration and improve efficiency. The workflow will now always run on pull requests to `main`, regardless of which files are changed, and the job timeout has been reduced.

**Workflow configuration improvements:**

* Removed the `paths` filter so the dependency review workflow runs on all pull requests to `main`, not just those modifying manifest files. This ensures the required status check is always satisfied, even if no dependency files are changed.
* Updated documentation comments to clarify the workflow's behavior and rationale for removing the path filter.

**Efficiency improvements:**

* Reduced the dependency review job timeout from 10 minutes to 5 minutes, making the workflow more efficient.Updated the dependency review workflow to remove specific paths and reduce timeout duration.