### PR TITLE
docs: update all readme files with accurate content and labeler badge

### DIFF
--- a/golang/readme.md
+++ b/golang/readme.md
@@ -1,35 +1,74 @@
 # Go Password Generator
 
-This is a simple command-line password generator written in Go. It generates passwords by creating a random mix of uppercase and lowercase letters, numbers, and special symbols.
+A command-line password generator written in Go. Generates a cryptographically reasonable random password from configurable character pools.
+
+## Prerequisites
+
+- [Go](https://go.dev/dl/) **1.22 or later**
+
+The only external dependency is [`github.com/urfave/cli/v2`](https://github.com/urfave/cli), managed automatically by Go modules.
+
+## Installation
+
+```bash
+cd golang
+go mod download
+go build -o password-generator .
+```
+
+Or run without building:
+
+```bash
+go run main.go [flags]
+```
 
 ## Usage
 
-To use the password generator, follow these steps:
-
-1. Build the program using the `go build` command.
-2. Run the program using the `./password-generator` command.
-
-## Example
-
-Here is an example of using the password generator:
-
-```bash
-./password-generator --l 12 --nn
+```text
+create-password [global options]
 ```
 
-This command generates a 12-character password without numbers.
+Running with no arguments generates an 8-character password using all character classes.
 
 ## Flags
 
-The password generator supports the following flags:
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--length` | `-l` | `8` | Total length of the generated password |
+| `--no-letters` | `-nle` | `false` | Exclude all letters (uppercase and lowercase) |
+| `--no-lowercase` | `-nl` | `false` | Exclude lowercase letters only |
+| `--no-numbers` | `-nn` | `false` | Exclude digits |
+| `--no-symbols` | `-ns` | `false` | Exclude special symbols |
+| `--no-uppercase` | `-nu` | `false` | Exclude uppercase letters only |
+| `--version` | `-v` | n/a | Print the application version and exit |
+| `--help` | `-h` | n/a | Print help text and exit |
 
-- `--length`, `-l`: Length of the password (default is 8).
-- `--no-numbers`, `-nn`: Exclude numbers from the password.
-- `--no-symbols`, `-ns`: Exclude special symbols from the password.
-- `--no-uppercase`, `-nu`: Exclude uppercase letters from the password.
-- `--no-lowercase`, `-nl`: Exclude lowercase letters from the password.
-- `--no-letters`, `-nle`: Exclude letters from the password.
+> `--no-letters` takes priority over `--no-lowercase` and `--no-uppercase`.
+
+## Examples
+
+```bash
+# Default: 8-character password with all character classes
+./password-generator
+
+# 12-character password without numbers
+./password-generator --length 12 --no-numbers
+
+# Numbers and symbols only
+./password-generator --no-letters
+
+# Uppercase letters and digits only
+./password-generator --no-lowercase --no-symbols
+
+# 32-character password with only digits and symbols
+./password-generator --no-letters --length 32
+```
 
 ## Tests
 
-To run the tests, use the `go test` command.
+```bash
+go test ./...
+
+# Verbose output
+go test -v ./...
+```

--- a/node/README.md
+++ b/node/README.md
@@ -1,41 +1,70 @@
-# node-cli-password-generator
+# Node.js / TypeScript Password Generator
 
-This repository contains a simple command-line application for generating passwords. It is built using Node.js and TypeScript and utilizes various libraries to generate random passwords and perform other functionalities.
+A command-line password generator built with Node.js and TypeScript. Generates a random password, copies it to the system clipboard automatically, and optionally saves it to a file.
+
+## Prerequisites
+
+- **Node.js 18 or later**
+- **npm** (bundled with Node.js)
 
 ## Installation
 
-To install the dependencies and compile the TypeScript source, run:
-
 ```bash
+cd node
 npm install
 npm run rebuild
 ```
 
+`npm run rebuild` erases `dist/` and recompiles the TypeScript source. Re-run it any time you modify files under `src/`.
+
 ## Usage
 
-To run the application and generate a password, use the following command `npm run save`
+```bash
+node ./dist/index [options]
+```
 
-This will generate a password with a default length of 8 characters and save it to the `passwords.txt` file.
+Running with no options generates an 8-character password, copies it to the clipboard, and prints a confirmation.
 
-You can also customize the behavior of the password generation using the following options:
+## Flags
 
-- `-l, --length`: Specify the length of the password (default: 8).
-- `-s, --save`: Save the generated password to the `passwords.txt` file.
-- `-n, --no-numbers`: Remove numbers from the generated password.
-- `-y, --no-symbols`: Remove symbols from the generated password.
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--length <number>` | `-l` | `8` | Total length of the generated password |
+| `--save` | `-s` | `false` | Append the password to `passwords.txt` |
+| `--no-numbers` | `-n` | `false` | Exclude digits |
+| `--no-symbols` | `-y` | `false` | Exclude special symbols |
+| `--version` | n/a | n/a | Print the application version and exit |
+| `--help` | `-h` | n/a | Print help text and exit |
 
-For example, to generate a password with a length of 20 characters and save it to the `passwords.txt` file, use the following command `node ./dist/index --length=20 -s`
+> Every invocation copies the password to the clipboard via `clipboardy`, regardless of other flags.
 
 ## Examples
 
-Generate a 20-character password and save it:
-node ./dist/index --length=20 --save
+```bash
+# Default: 8-character password (copied to clipboard)
+node ./dist/index
+
+# 20-character password, saved to passwords.txt
+node ./dist/index --length 20 --save
+
+# Letters only (no digits, no symbols), saved to passwords.txt
+node ./dist/index --no-numbers --no-symbols --save
+```
+
+### npm convenience scripts
+
+```bash
+npm run save           # Generate and save to passwords.txt
+npm run no-numbers     # Exclude digits, save to passwords.txt
+npm run no-symbols     # Exclude symbols, save to passwords.txt
+npm run only-letters   # Exclude both digits and symbols, save to passwords.txt
+```
 
 ## Dependencies
 
-The application relies on the following dependencies:
-
-- [chalk](https://www.npmjs.com/package/chalk): Library for styling the command-line output.
-- [clipboardy](https://www.npmjs.com/package/clipboardy): Library for accessing the system clipboard.
-- [commander](https://www.npmjs.com/package/commander): Library for building command-line interfaces.
-- [random-seed](https://www.npmjs.com/package/random-seed): Library for generating random numbers using a seed.
+| Package | Purpose |
+| --- | --- |
+| `commander` | CLI argument parsing |
+| `chalk` | Terminal output colouring |
+| `clipboardy` | Copies the password to the system clipboard |
+| `random-seed` | Seedable pseudo-random number generator |

--- a/python/readme.md
+++ b/python/readme.md
@@ -48,13 +48,7 @@ You can do the same with the .exe included by just doing `./password_generator.e
 The script comes with a comprehensive test suite to ensure functionality. To run the tests, navigate to the project directory and execute:
 
 ```bash
-python -m unittest
-```
-
-or
-
-```bash
-python -m unittest -v
+python3 -m unittest test_module.py -v
 ```
 
 This command will run all defined tests, checking the correctness of the password generator under various conditions.

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 [![CodeQL](https://github.com/milliorn/cli-password-generators/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/milliorn/cli-password-generators/actions/workflows/github-code-scanning/codeql)
 [![Dependabot reviewer](https://github.com/milliorn/cli-password-generators/actions/workflows/automerge.yml/badge.svg)](https://github.com/milliorn/cli-password-generators/actions/workflows/automerge.yml)
 [![Dependabot Updates](https://github.com/milliorn/cli-password-generators/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/milliorn/cli-password-generators/actions/workflows/dependabot/dependabot-updates)
+[![Labeler](https://github.com/milliorn/cli-password-generators/actions/workflows/label.yml/badge.svg)](https://github.com/milliorn/cli-password-generators/actions/workflows/label.yml)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Add `Labeler` workflow badge to the root readme
- Fix incorrect flag syntax in golang readme (`--l` → `--length`) and add the full flags table
- Rewrite node README with accurate flag table and all npm convenience scripts
- Fix python readme test command (`python` → `python3`, target `test_module.py` directly)

## Test plan

- [ ] Verify the `documentation` label is applied automatically by the labeler workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)