### PR TITLE
Rename gatekeeper job to merge-gatekeeper for clarity

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  gatekeeper:
+  merge-gatekeeper:
     runs-on: ubuntu-latest
     permissions:
       checks: read


### PR DESCRIPTION
Clarify the naming of the CI job by renaming it from "gatekeeper" to "merge-gatekeeper." This change enhances understanding of the job's purpose.